### PR TITLE
Make stamina not send networking even outside of MP

### DIFF
--- a/Lua/Autorun/stamina.lua
+++ b/Lua/Autorun/stamina.lua
@@ -28,8 +28,10 @@ local function LoseStamina(character)
     if stamina.Strength > 20 then
         stamina.Strength = stamina.Strength - 20
     end
-
-    Networking.CreateEntityEvent(character, Character.CharacterStatusEventData.__new(true))
+    
+    if not Game.IsMultiplayer then
+        Networking.CreateEntityEvent(character, Character.CharacterStatusEventData.__new(true))
+    end
 end
 
 local countdown = 60


### PR DESCRIPTION
Makes the stamina code not send the networking event unless the game is multiplayer. Prevents errors in singleplayer